### PR TITLE
Add flag handling for agent and server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,55 @@
-# metrics service
+# Metrics Service
+
+This project is a simple metrics service that allows for the storage, retrieval, and updating of various types of metrics, such as gauges and counters. Built using Go and the Chi routing package, this service can be integrated into larger applications for monitoring and metrics management.
+
+## Features
+
+- **Store Metrics**: Supports gauge and counter metrics.
+- **Retrieve Metrics**: Fetch the current value of a specific metric by type and name.
+- **List Metrics**: Serve an HTML page listing all known metrics and their values.
+- **Concurrency Support**: Uses memory storage with proper synchronization for concurrent access.
+
+## Installation
+
+To get started, clone this repository:
+
+```bash
+git clone <repository-url>
+cd metrics-service
+```
+
+Prerequisites
+Make sure you have Go installed on your machine. You can download it from the official Go website.
+
+## Usage
+
+Run the Service: Use the following command to start the service:
+
+```bash
+go run cmd/agent/main.go
+```
+Update Metrics: Send a POST request to update a metric. For example:
+
+```bash
+curl -X POST http://localhost:8080/update/gauge/testGauge/10.5
+```
+Retrieve a Metric Value: Send a GET request to fetch the value of a specific metric:
+
+```bash
+curl http://localhost:8080/value/gauge/testGauge
+```
+
+List All Metrics: Access the root URL to see a list of all metrics in HTML format:
+
+```bash
+curl http://localhost:8080/
+```
+
+## Contributing
+
+Contributions are welcome! If you'd like to contribute to this project, please fork the repository and create a pull request.
+
+## License
+
+This project is licensed under the MIT License. See the LICENSE file for details.
+Feel free to modify the content to better fit your project's specifics or to add any additional sections that you think might be relevant!

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -2,8 +2,11 @@ package main
 
 import (
 	"bytes"
+	"flag"
+	"fmt"
 	"math/rand"
 	"net/http"
+	"os"
 	"runtime"
 	"strconv"
 	"time"
@@ -82,8 +85,8 @@ func (m *Metrics) collectMetrics() {
 	m.RandomValue = randomValue()
 }
 
-func sendMetric(metricType, metricName string, value float64) {
-	url := "http://localhost:8080/update/" + metricType + "/" + metricName + "/" + strconv.FormatFloat(value, 'f', 1, 64)
+func sendMetric(metricType, metricName string, value float64, serverAddress string) {
+	url := "http://" + serverAddress + "/update/" + metricType + "/" + metricName + "/" + strconv.FormatFloat(value, 'f', 1, 64)
 	req, err := http.NewRequest("POST", url, bytes.NewBuffer(nil))
 	if err != nil {
 		panic(err)
@@ -99,48 +102,59 @@ func sendMetric(metricType, metricName string, value float64) {
 }
 
 func main() {
+	reportInterval := flag.Int("r", 10, "Report interval in seconds")
+	pollInterval := flag.Int("p", 2, "Poll interval in seconds")
+	serverAddress := flag.String("a", "localhost:8080", "server address")
+
+	flag.Parse()
+
+	if len(flag.Args()) > 0 {
+		fmt.Printf("Error: Unknown flags or arguments: %v\n", flag.Args())
+		os.Exit(1)
+	}
+
 	metrics := &Metrics{}
 
 	go func() {
 		for {
 			metrics.collectMetrics()
-			time.Sleep(2 * time.Second)
+			time.Sleep(time.Duration(*pollInterval) * time.Second)
 		}
 	}()
 
 	go func() {
 		for {
-			sendMetric("gauge", "Alloc", metrics.Alloc)
-			sendMetric("gauge", "BuckHashSys", metrics.BuckHashSys)
-			sendMetric("gauge", "Frees", metrics.Frees)
-			sendMetric("gauge", "GCCPUFraction", metrics.GCCPUFraction)
-			sendMetric("gauge", "GCSys", metrics.GCSys)
-			sendMetric("gauge", "HeapAlloc", metrics.HeapAlloc)
-			sendMetric("gauge", "HeapIdle", metrics.HeapIdle)
-			sendMetric("gauge", "HeapInuse", metrics.HeapInuse)
-			sendMetric("gauge", "HeapObjects", metrics.HeapObjects)
-			sendMetric("gauge", "HeapReleased", metrics.HeapReleased)
-			sendMetric("gauge", "HeapSys", metrics.HeapSys)
-			sendMetric("gauge", "LastGC", metrics.LastGC)
-			sendMetric("gauge", "Lookups", metrics.Lookups)
-			sendMetric("gauge", "MCacheInuse", metrics.MCacheInuse)
-			sendMetric("gauge", "MCacheSys", metrics.MCacheSys)
-			sendMetric("gauge", "MSpanInuse", metrics.MSpanInuse)
-			sendMetric("gauge", "MSpanSys", metrics.MSpanSys)
-			sendMetric("gauge", "Mallocs", metrics.Mallocs)
-			sendMetric("gauge", "NextGC", metrics.NextGC)
-			sendMetric("gauge", "NumForcedGC", metrics.NumForcedGC)
-			sendMetric("gauge", "NumGC", metrics.NumGC)
-			sendMetric("gauge", "OtherSys", metrics.OtherSys)
-			sendMetric("gauge", "PauseTotalNs", metrics.PauseTotalNs)
-			sendMetric("gauge", "StackInuse", metrics.StackInuse)
-			sendMetric("gauge", "StackSys", metrics.StackSys)
-			sendMetric("gauge", "Sys", metrics.Sys)
-			sendMetric("gauge", "TotalAlloc", metrics.TotalAlloc)
+			sendMetric("gauge", "Alloc", metrics.Alloc, *serverAddress)
+			sendMetric("gauge", "BuckHashSys", metrics.BuckHashSys, *serverAddress)
+			sendMetric("gauge", "Frees", metrics.Frees, *serverAddress)
+			sendMetric("gauge", "GCCPUFraction", metrics.GCCPUFraction, *serverAddress)
+			sendMetric("gauge", "GCSys", metrics.GCSys, *serverAddress)
+			sendMetric("gauge", "HeapAlloc", metrics.HeapAlloc, *serverAddress)
+			sendMetric("gauge", "HeapIdle", metrics.HeapIdle, *serverAddress)
+			sendMetric("gauge", "HeapInuse", metrics.HeapInuse, *serverAddress)
+			sendMetric("gauge", "HeapObjects", metrics.HeapObjects, *serverAddress)
+			sendMetric("gauge", "HeapReleased", metrics.HeapReleased, *serverAddress)
+			sendMetric("gauge", "HeapSys", metrics.HeapSys, *serverAddress)
+			sendMetric("gauge", "LastGC", metrics.LastGC, *serverAddress)
+			sendMetric("gauge", "Lookups", metrics.Lookups, *serverAddress)
+			sendMetric("gauge", "MCacheInuse", metrics.MCacheInuse, *serverAddress)
+			sendMetric("gauge", "MCacheSys", metrics.MCacheSys, *serverAddress)
+			sendMetric("gauge", "MSpanInuse", metrics.MSpanInuse, *serverAddress)
+			sendMetric("gauge", "MSpanSys", metrics.MSpanSys, *serverAddress)
+			sendMetric("gauge", "Mallocs", metrics.Mallocs, *serverAddress)
+			sendMetric("gauge", "NextGC", metrics.NextGC, *serverAddress)
+			sendMetric("gauge", "NumForcedGC", metrics.NumForcedGC, *serverAddress)
+			sendMetric("gauge", "NumGC", metrics.NumGC, *serverAddress)
+			sendMetric("gauge", "OtherSys", metrics.OtherSys, *serverAddress)
+			sendMetric("gauge", "PauseTotalNs", metrics.PauseTotalNs, *serverAddress)
+			sendMetric("gauge", "StackInuse", metrics.StackInuse, *serverAddress)
+			sendMetric("gauge", "StackSys", metrics.StackSys, *serverAddress)
+			sendMetric("gauge", "Sys", metrics.Sys, *serverAddress)
+			sendMetric("gauge", "TotalAlloc", metrics.TotalAlloc, *serverAddress)
 
-			sendMetric("counter", "PollCount", float64(metrics.PollCount))
-			sendMetric("gauge", "RandomValue", metrics.RandomValue)
-			time.Sleep(10 * time.Second)
+			sendMetric("counter", "PollCount", float64(metrics.PollCount), *serverAddress)
+			sendMetric("gauge", "RandomValue", metrics.RandomValue, *serverAddress)
+			time.Sleep(time.Duration(*reportInterval) * time.Second)
 		}
 	}()
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,14 +1,24 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"github.com/go-chi/chi/v5"
 	"github.com/hairutdin/metrics-service/handlers"
 	"github.com/hairutdin/metrics-service/storage"
 	"net/http"
+	"os"
 )
 
 func main() {
+	serverAddress := flag.String("a", "localhost:8080", "server address")
+	flag.Parse()
+
+	if len(flag.Args()) > 0 {
+		fmt.Printf("Error: Unknown flags or arguments: %v\n", flag.Args())
+		os.Exit(1)
+	}
+
 	memStorage := storage.NewMemStorage()
 	r := chi.NewRouter()
 
@@ -18,8 +28,8 @@ func main() {
 	r.Get("/value/{type}/{name}", metricsHandler.HandleGetValue)
 	r.Get("/", metricsHandler.HandleListMetrics)
 
-	fmt.Println("Server is running at http://localhost:8080")
-	err := http.ListenAndServe(":8080", r)
+	fmt.Printf("Server is running at http://%s\n", *serverAddress)
+	err := http.ListenAndServe(*serverAddress, r)
 	if err != nil {
 		fmt.Printf("Server failed to start: %v\n", err)
 	}


### PR DESCRIPTION
- Implemented flag handling for agent (-a, -r, -p) and server (-a) with default values.
- Introduced error handling to terminate the application when unknown flags are passed, displaying an appropriate error message.
- Set default values for reportInterval, pollInterval, and server address as specified (localhost:8080).
- Ensured all interval values are specified in seconds.




