### PR TITLE
Add Gzip Support to Agent and Server

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.20'
+        go-version: '1.23'
 
     - name: Build
       run: go build -v ./...

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -32,6 +32,8 @@ func main() {
 
 	logger := logrus.New()
 	r.Use(middleware.Logger(logger))
+	r.Use(middleware.GzipDecompress)
+	r.Use(middleware.GzipCompress)
 
 	metricsHandler := handlers.NewMetricsHandler(memStorage)
 

--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,9 @@ module github.com/hairutdin/metrics-service
 
 go 1.22.5
 
-require github.com/go-chi/chi/v5 v5.1.0
-
 require (
-	github.com/sirupsen/logrus v1.9.3 // indirect
-	golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 // indirect
+	github.com/go-chi/chi/v5 v5.1.0
+	github.com/sirupsen/logrus v1.9.3
 )
+
+require golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hairutdin/metrics-service
 
-go 1.22.5
+go 1.23
 
 require (
 	github.com/go-chi/chi/v5 v5.1.0

--- a/go.sum
+++ b/go.sum
@@ -1,13 +1,17 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-chi/chi/v5 v5.1.0 h1:acVI1TYaD+hhedDJ3r54HyA6sExp3HfXq7QWEEY/xMw=
 github.com/go-chi/chi/v5 v5.1.0/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 h1:0A+M6Uqn+Eje4kHMK80dtF3JCXC4ykBgQG4Fe06QRhQ=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/middleware/gzip.go
+++ b/internal/middleware/gzip.go
@@ -1,0 +1,53 @@
+package middleware
+
+import (
+	"compress/gzip"
+	"io"
+	"net/http"
+	"strings"
+)
+
+type gzipResponseWriter struct {
+	http.ResponseWriter
+	writer *gzip.Writer
+}
+
+func (w *gzipResponseWriter) Write(b []byte) (int, error) {
+	return w.writer.Write(b)
+}
+
+func GzipDecompress(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Content-Encoding") == "gzip" {
+			contentType := r.Header.Get("Content-Type")
+			if strings.Contains(contentType, "application/json") || strings.Contains(contentType, "text/html") {
+				gzReader, err := gzip.NewReader(r.Body)
+				if err != nil {
+					http.Error(w, "Invalid gzip data", http.StatusBadRequest)
+					return
+				}
+				defer gzReader.Close()
+
+				r.Body = io.NopCloser(gzReader)
+			}
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+func GzipCompress(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.Header.Get("Accept-Encoding"), "gzip") {
+			w.Header().Set("Content-Encoding", "gzip")
+			gzWriter := gzip.NewWriter(w)
+			defer gzWriter.Close()
+
+			gzipWriter := &gzipResponseWriter{ResponseWriter: w, writer: gzWriter}
+			next.ServeHTTP(gzipWriter, r)
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}


### PR DESCRIPTION
- Updated the agent to compress outgoing data using gzip when sending metrics to the server.
- Implemented middleware on the server to handle gzipped incoming requests and decompress them if the Content-Encoding: gzip header is present.
- Added functionality for the server to detect the client's Accept-Encoding: gzip header and compress responses accordingly.