### PR TITLE
Add periodic metric storage, restoration

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -3,23 +3,69 @@ package main
 import (
 	"flag"
 	"fmt"
+	"net/http"
+	"os"
+	"os/signal"
+	"strconv"
+	"syscall"
+	"time"
+
 	"github.com/go-chi/chi/v5"
 	"github.com/hairutdin/metrics-service/handlers"
 	"github.com/hairutdin/metrics-service/internal/middleware"
 	"github.com/hairutdin/metrics-service/storage"
 	"github.com/sirupsen/logrus"
-	"net/http"
-	"os"
 )
+
+func startMetricSaver(interval int, filePath string, storage *storage.MemStorage) {
+	if interval == 0 {
+		storage.EnableSyncSaving(filePath)
+		return
+	}
+
+	ticker := time.NewTicker(time.Duration(interval) * time.Second)
+	go func() {
+		for {
+			<-ticker.C
+			storage.SaveMetricsToFile(filePath)
+		}
+	}()
+
+}
 
 func main() {
 	flagServerAddress := flag.String("a", "localhost:8080", "server address")
+	flagStoreInterval := flag.Int("i", 300, "Store interval in seconds")
+	flagFilePath := flag.String("f", "/tmp/metrics-db.json", "File path to save metrics")
+	flagRestore := flag.Bool("r", true, "Restore metrics from file on startup")
 	flag.Parse()
 
 	envServerAddress := os.Getenv("SERVER_ADDRESS")
+	envStoreInterval := os.Getenv("STORE_INTERVAL")
+	envFilePath := os.Getenv("FILE_STORAGE_PATH")
+	envRestore := os.Getenv("RESTORE")
+
 	serverAddress := *flagServerAddress
 	if envServerAddress != "" {
 		serverAddress = envServerAddress
+	}
+	storeInterval := *flagStoreInterval
+	if envStoreInterval != "" {
+		interval, err := strconv.Atoi(envStoreInterval)
+		if err == nil {
+			storeInterval = interval
+		}
+	}
+	filePath := *flagFilePath
+	if envFilePath != "" {
+		filePath = envFilePath
+	}
+	restore := *flagRestore
+	if envRestore != "" {
+		restoreBool, err := strconv.ParseBool(envRestore)
+		if err == nil {
+			restore = restoreBool
+		}
 	}
 
 	if len(flag.Args()) > 0 {
@@ -28,22 +74,41 @@ func main() {
 	}
 
 	memStorage := storage.NewMemStorage()
-	r := chi.NewRouter()
 
+	if restore {
+		err := memStorage.RestoreMetricsFromFile(filePath)
+		if err != nil {
+			fmt.Printf("Error restoring metrics from file: %v\n", err)
+		}
+	}
+
+	stop := make(chan os.Signal, 1)
+	signal.Notify(stop, os.Interrupt, syscall.SIGTERM)
+
+	startMetricSaver(storeInterval, filePath, memStorage)
+
+	r := chi.NewRouter()
 	logger := logrus.New()
 	r.Use(middleware.Logger(logger))
 	r.Use(middleware.GzipDecompress)
 	r.Use(middleware.GzipCompress)
 
 	metricsHandler := handlers.NewMetricsHandler(memStorage)
-
 	r.Post("/update/", metricsHandler.HandleUpdateJSON)
 	r.Post("/value/", metricsHandler.HandleGetValueJSON)
 	r.Get("/", metricsHandler.HandleListMetrics)
 
-	fmt.Printf("Server is running at http://%s\n", serverAddress)
-	err := http.ListenAndServe(serverAddress, r)
-	if err != nil {
-		fmt.Printf("Server failed to start: %v\n", err)
-	}
+	go func() {
+		fmt.Printf("Server is running at http://%s\n", serverAddress)
+		err := http.ListenAndServe(serverAddress, r)
+		if err != nil {
+			fmt.Printf("Server failed to start: %v\n", err)
+		}
+	}()
+
+	<-stop
+
+	fmt.Println("Shutting down server... Saving metrics.")
+	memStorage.SaveMetricsToFile(filePath)
+	os.Exit(0)
 }

--- a/storage/mem_storage.go
+++ b/storage/mem_storage.go
@@ -1,8 +1,11 @@
 package storage
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
 	"sync"
+	"time"
 )
 
 type MemStorage struct {
@@ -61,4 +64,65 @@ func (s *MemStorage) GetAllMetrics() map[string]string {
 		metrics[name] = fmt.Sprintf("counter: %d", value)
 	}
 	return metrics
+}
+
+func (s *MemStorage) SaveMetricsToFile(filePath string) error {
+	s.RLock()
+	defer s.RUnlock()
+
+	data := struct {
+		Gauges   map[string]float64 `json:"gauges"`
+		Counters map[string]int64   `json:"counters"`
+	}{
+		Gauges:   s.Gauges,
+		Counters: s.Counters,
+	}
+
+	file, err := os.Create(filePath)
+	if err != nil {
+		return fmt.Errorf("error creating file: %v", err)
+	}
+	defer file.Close()
+
+	encoder := json.NewEncoder(file)
+	if err := encoder.Encode(data); err != nil {
+		return fmt.Errorf("error encoding metrics to file: %v", err)
+	}
+
+	return nil
+}
+
+func (s *MemStorage) RestoreMetricsFromFile(filePath string) error {
+	s.Lock()
+	defer s.Unlock()
+
+	file, err := os.Open(filePath)
+	if err != nil {
+		return fmt.Errorf("error opening file: %v", err)
+	}
+	defer file.Close()
+
+	data := struct {
+		Gauges   map[string]float64 `json:"gauges"`
+		Counters map[string]int64   `json:"counters"`
+	}{}
+
+	decoder := json.NewDecoder(file)
+	if err := decoder.Decode(&data); err != nil {
+		return fmt.Errorf("error decoding metrics from file: %v", err)
+	}
+
+	s.Gauges = data.Gauges
+	s.Counters = data.Counters
+
+	return nil
+}
+
+func (s *MemStorage) EnableSyncSaving(filePath string) {
+	go func() {
+		for {
+			time.Sleep(1 * time.Second)
+			s.SaveMetricsToFile(filePath)
+		}
+	}()
 }


### PR DESCRIPTION
- Implemented periodic saving of server metrics to a disk file, with interval configurable via the STORE_INTERVAL flag or environment variable.
- Added support for restoring metrics from disk at server startup, controlled by the RESTORE flag or environment variable.
- Configured the file path for metric storage using the FILE_STORAGE_PATH flag or environment variable. Saving is disabled when the path is empty.
- Ensured that all metrics are saved upon graceful server shutdown.