### PR TITLE
Add batch metric handling with /updates endpoint

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -38,6 +38,13 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: '1.23'
+      
+      - name: Set up PostgreSQL
+        run: |
+          psql -U postgres -c "CREATE DATABASE metrics_service_test;"
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
 
       - name: Build
         run: go build -v ./...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -37,7 +37,7 @@ jobs:
       
       - name: Wait for PostgreSQL to start
         run: |
-          until psql -U postgres -c "SELECT 1"; do
+          until pg_isready -h localhost -p 5432 -U postgres; do
             echo "Waiting for PostgreSQL to be ready..."
             sleep 1
           done
@@ -47,7 +47,7 @@ jobs:
       
       - name: Build
         run: go build -v ./...
-        
+
       - name: Run Tests
         env:
           DATABASE_DSN: "postgres://postgres:postgres@localhost:5432/metrics_service_test?sslmode=disable"

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -43,6 +43,8 @@ jobs:
           done
 
       - name: Create test database
+        env:
+          PGPASSWORD: postgres
         run:  psql -h localhost -U postgres -c "CREATE DATABASE metrics_service_test;"
 
       

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -43,7 +43,8 @@ jobs:
           done
 
       - name: Create test database
-        run: psql -U postgres -c "CREATE DATABASE metrics_service_test;"
+        run:  psql -h localhost -U postgres -c "CREATE DATABASE metrics_service_test;"
+
       
       - name: Build
         run: go build -v ./...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,8 +18,7 @@ jobs:
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: metrics_service
-          DATABASE_DSN: "postgres://postgres:postgres@localhost:5432/metrics_service?sslmode=disable"
+          POSTGRES_DB: postgres
         ports:
           - 5432:5432
         options: >-
@@ -27,9 +26,6 @@ jobs:
           --health-interval=10s
           --health-timeout=5s
           --health-retries=5
-
-    env:
-      DATABASE_DSN: "postgres://postgres:postgres@localhost:5432/metrics_service?sslmode=disable"
 
     steps:
       - uses: actions/checkout@v4
@@ -39,15 +35,20 @@ jobs:
         with:
           go-version: '1.23'
       
-      - name: Set up PostgreSQL
+      - name: Wait for PostgreSQL to start
         run: |
-          psql -U postgres -c "CREATE DATABASE metrics_service_test;"
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
+          until psql -U postgres -c "SELECT 1"; do
+            echo "Waiting for PostgreSQL to be ready..."
+            sleep 1
+          done
 
+      - name: Create test database
+        run: psql -U postgres -c "CREATE DATABASE metrics_service_test;"
+      
       - name: Build
         run: go build -v ./...
-      
-      - name: Test
+        
+      - name: Run Tests
+        env:
+          DATABASE_DSN: "postgres://postgres:postgres@localhost:5432/metrics_service_test?sslmode=disable"
         run: go test -v ./...

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"github.com/hairutdin/metrics-service/models"
 	"math/rand"
 	"net/http"
 	"os"
@@ -14,12 +15,12 @@ import (
 	"time"
 )
 
-type Metrics struct {
-	ID    string   `json:"id"`
-	MType string   `json:"type"`
-	Delta *int64   `json:"delta,omitempty"`
-	Value *float64 `json:"value,omitempty"`
-}
+// type Metrics struct {
+// 	ID    string   `json:"id"`
+// 	MType string   `json:"type"`
+// 	Delta *int64   `json:"delta,omitempty"`
+// 	Value *float64 `json:"value,omitempty"`
+// }
 
 type RuntimeMetrics struct {
 	Alloc         float64
@@ -95,7 +96,7 @@ func (m *RuntimeMetrics) collectMetrics() {
 }
 
 func sendMetric(metricType, metricName string, delta *int64, value *float64, serverAddress string) {
-	metric := Metrics{
+	metric := models.Metrics{
 		ID:    metricName,
 		MType: metricType,
 		Delta: delta,

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -6,13 +6,14 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"github.com/hairutdin/metrics-service/models"
 	"math/rand"
 	"net/http"
 	"os"
 	"runtime"
 	"strconv"
 	"time"
+
+	"github.com/hairutdin/metrics-service/models"
 )
 
 // type Metrics struct {
@@ -138,6 +139,42 @@ func sendMetric(metricType, metricName string, delta *int64, value *float64, ser
 	defer resp.Body.Close()
 }
 
+func sendMetricsBatch(metrics []models.Metrics, serverAddress string) {
+	jsonData, err := json.Marshal(metrics)
+	if err != nil {
+		panic(fmt.Sprintf("Failed to marshal metrics: %v", err))
+	}
+
+	var buf bytes.Buffer
+	gzipWriter := gzip.NewWriter(&buf)
+	_, err = gzipWriter.Write(jsonData)
+	if err != nil {
+		panic(fmt.Sprintf("Failed to write to gzip writer: %v", err))
+	}
+
+	if err := gzipWriter.Close(); err != nil {
+		panic(fmt.Sprintf("Failed to close gzip writer: %v", err))
+	}
+
+	url := "http://" + serverAddress + "/updates/"
+	req, err := http.NewRequest("POST", url, &buf)
+	if err != nil {
+		panic(fmt.Sprintf("Failed to create request: %v", err))
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Content-Encoding", "gzip")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		fmt.Printf("Failed to send metrics batch: %v\n", err)
+		return
+	}
+	defer resp.Body.Close()
+
+}
+
 func main() {
 	flagReportInterval := flag.Int("r", 10, "Report interval in seconds")
 	flagPollInterval := flag.Int("p", 2, "Poll interval in seconds")
@@ -179,7 +216,6 @@ func main() {
 	}
 
 	metrics := &RuntimeMetrics{}
-
 	go func() {
 		for {
 			metrics.collectMetrics()
@@ -189,36 +225,39 @@ func main() {
 
 	go func() {
 		for {
-			sendMetric("gauge", "Alloc", nil, &metrics.Alloc, serverAddress)
-			sendMetric("gauge", "BuckHashSys", nil, &metrics.BuckHashSys, serverAddress)
-			sendMetric("gauge", "Frees", nil, &metrics.Frees, serverAddress)
-			sendMetric("gauge", "GCCPUFraction", nil, &metrics.GCCPUFraction, serverAddress)
-			sendMetric("gauge", "GCSys", nil, &metrics.GCSys, serverAddress)
-			sendMetric("gauge", "HeapAlloc", nil, &metrics.HeapAlloc, serverAddress)
-			sendMetric("gauge", "HeapIdle", nil, &metrics.HeapIdle, serverAddress)
-			sendMetric("gauge", "HeapInuse", nil, &metrics.HeapInuse, serverAddress)
-			sendMetric("gauge", "HeapObjects", nil, &metrics.HeapObjects, serverAddress)
-			sendMetric("gauge", "HeapReleased", nil, &metrics.HeapReleased, serverAddress)
-			sendMetric("gauge", "HeapSys", nil, &metrics.HeapSys, serverAddress)
-			sendMetric("gauge", "LastGC", nil, &metrics.LastGC, serverAddress)
-			sendMetric("gauge", "Lookups", nil, &metrics.Lookups, serverAddress)
-			sendMetric("gauge", "MCacheInuse", nil, &metrics.MCacheInuse, serverAddress)
-			sendMetric("gauge", "MCacheSys", nil, &metrics.MCacheSys, serverAddress)
-			sendMetric("gauge", "MSpanInuse", nil, &metrics.MSpanInuse, serverAddress)
-			sendMetric("gauge", "MSpanSys", nil, &metrics.MSpanSys, serverAddress)
-			sendMetric("gauge", "Mallocs", nil, &metrics.Mallocs, serverAddress)
-			sendMetric("gauge", "NextGC", nil, &metrics.NextGC, serverAddress)
-			sendMetric("gauge", "NumForcedGC", nil, &metrics.NumForcedGC, serverAddress)
-			sendMetric("gauge", "NumGC", nil, &metrics.NumGC, serverAddress)
-			sendMetric("gauge", "OtherSys", nil, &metrics.OtherSys, serverAddress)
-			sendMetric("gauge", "PauseTotalNs", nil, &metrics.PauseTotalNs, serverAddress)
-			sendMetric("gauge", "StackInuse", nil, &metrics.StackInuse, serverAddress)
-			sendMetric("gauge", "StackSys", nil, &metrics.StackSys, serverAddress)
-			sendMetric("gauge", "Sys", nil, &metrics.Sys, serverAddress)
-			sendMetric("gauge", "TotalAlloc", nil, &metrics.TotalAlloc, serverAddress)
+			metricList := []models.Metrics{
+				{ID: "Alloc", MType: "gauge", Value: &metrics.Alloc},
+				{ID: "BuckHashSys", MType: "gauge", Value: &metrics.BuckHashSys},
+				{ID: "Frees", MType: "gauge", Value: &metrics.Frees},
+				{ID: "GCCPUFraction", MType: "gauge", Value: &metrics.GCCPUFraction},
+				{ID: "GCSys", MType: "gauge", Value: &metrics.GCSys},
+				{ID: "HeapAlloc", MType: "gauge", Value: &metrics.HeapAlloc},
+				{ID: "HeapIdle", MType: "gauge", Value: &metrics.HeapIdle},
+				{ID: "HeapInuse", MType: "gauge", Value: &metrics.HeapInuse},
+				{ID: "HeapObjects", MType: "gauge", Value: &metrics.HeapObjects},
+				{ID: "HeapReleased", MType: "gauge", Value: &metrics.HeapReleased},
+				{ID: "HeapSys", MType: "gauge", Value: &metrics.HeapSys},
+				{ID: "LastGC", MType: "gauge", Value: &metrics.LastGC},
+				{ID: "Lookups", MType: "gauge", Value: &metrics.Lookups},
+				{ID: "MCacheInuse", MType: "gauge", Value: &metrics.MCacheInuse},
+				{ID: "MCacheSys", MType: "gauge", Value: &metrics.MCacheSys},
+				{ID: "MSpanInuse", MType: "gauge", Value: &metrics.MSpanInuse},
+				{ID: "MSpanSys", MType: "gauge", Value: &metrics.MSpanSys},
+				{ID: "Mallocs", MType: "gauge", Value: &metrics.Mallocs},
+				{ID: "NextGC", MType: "gauge", Value: &metrics.NextGC},
+				{ID: "NumForcedGC", MType: "gauge", Value: &metrics.NumForcedGC},
+				{ID: "NumGC", MType: "gauge", Value: &metrics.NumGC},
+				{ID: "OtherSys", MType: "gauge", Value: &metrics.OtherSys},
+				{ID: "PauseTotalNs", MType: "gauge", Value: &metrics.PauseTotalNs},
+				{ID: "StackInuse", MType: "gauge", Value: &metrics.StackInuse},
+				{ID: "StackSys", MType: "gauge", Value: &metrics.StackSys},
+				{ID: "Sys", MType: "gauge", Value: &metrics.Sys},
+				{ID: "TotalAlloc", MType: "gauge", Value: &metrics.TotalAlloc},
+				{ID: "PollCount", MType: "counter", Delta: &metrics.PollCount},
+				{ID: "RandomValue", MType: "gauge", Value: &metrics.RandomValue},
+			}
 
-			sendMetric("counter", "PollCount", &metrics.PollCount, nil, serverAddress)
-			sendMetric("gauge", "RandomValue", nil, &metrics.RandomValue, serverAddress)
+			sendMetricsBatch(metricList, serverAddress)
 			time.Sleep(time.Duration(reportInterval) * time.Second)
 		}
 	}()

--- a/cmd/agent/main_test.go
+++ b/cmd/agent/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"github.com/hairutdin/metrics-service/models"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -27,7 +28,7 @@ func TestSendMetric(t *testing.T) {
 			t.Errorf("Expected application/json content type, got %s", r.Header.Get("Content-Type"))
 		}
 
-		var metric Metrics
+		var metric models.Metrics
 		err := json.NewDecoder(r.Body).Decode(&metric)
 		if err != nil {
 			t.Fatalf("Failed to decode JSON: %v", err)
@@ -49,7 +50,7 @@ func TestSendMetric(t *testing.T) {
 	defer server.Close()
 
 	sendMetric := func(metricType, metricName string, value float64) {
-		metric := Metrics{
+		metric := models.Metrics{
 			ID:    metricName,
 			MType: metricType,
 			Value: &value,

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/hairutdin/metrics-service/handlers"
 	"github.com/hairutdin/metrics-service/internal/middleware"
+	"github.com/hairutdin/metrics-service/models"
 	"github.com/hairutdin/metrics-service/storage"
 	"github.com/stretchr/testify/assert"
 )
@@ -34,7 +35,7 @@ func testSetupRouter() *chi.Mux {
 
 func TestUpdateMetric(t *testing.T) {
 	router := testSetupRouter()
-	metric := handlers.Metrics{
+	metric := models.Metrics{
 		ID:    "test_metric",
 		MType: "gauge",
 		Value: func(v float64) *float64 { return &v }(12.5),
@@ -58,7 +59,7 @@ func TestGetValueMetric(t *testing.T) {
 	storage.UpdateGauge("test_metric", 12.5)
 	router := setupRouter(storage)
 
-	metric := handlers.Metrics{
+	metric := models.Metrics{
 		ID:    "test_metric",
 		MType: "gauge",
 	}
@@ -75,7 +76,7 @@ func TestGetValueMetric(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, rr.Code, "Expected status 200 OK")
 
-	var response handlers.Metrics
+	var response models.Metrics
 	err = json.Unmarshal(rr.Body.Bytes(), &response)
 	assert.NoError(t, err)
 

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -8,25 +8,17 @@ import (
 	"log"
 )
 
-var DB *pgx.Conn
-
-func ConnectToDB(dsn string) error {
-	var err error
-	DB, err = pgx.Connect(context.Background(), dsn)
+func ConnectToDB(dsn string) (*pgx.Conn, error) {
+	conn, err := pgx.Connect(context.Background(), dsn)
 	if err != nil {
 		log.Printf("Unable to connect to database: %v\n", err)
-		return err
+		return nil, err
 	}
 
-	err = initializeTables()
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return conn, nil
 }
 
-func initializeTables() error {
+func InitializeTables(conn *pgx.Conn) error {
 	gaugeTableQuery := `
 	CREATE TABLE IF NOT EXISTS gauge_metrics (
 		name TEXT PRIMARY KEY,
@@ -40,12 +32,12 @@ func initializeTables() error {
 	)
 	`
 
-	_, err := DB.Exec(context.Background(), gaugeTableQuery)
+	_, err := conn.Exec(context.Background(), gaugeTableQuery)
 	if err != nil {
 		return fmt.Errorf("failed to create gauge_metrics table: %w", err)
 	}
 
-	_, err = DB.Exec(context.Background(), counterTableQuery)
+	_, err = conn.Exec(context.Background(), counterTableQuery)
 	if err != nil {
 		return fmt.Errorf("failed to create counter_metrics table: %w", err)
 	}
@@ -53,12 +45,12 @@ func initializeTables() error {
 	return nil
 }
 
-func PingDB() error {
-	return DB.Ping(context.Background())
+func PingDB(conn *pgx.Conn) error {
+	return conn.Ping(context.Background())
 }
 
-func CloseDB() {
-	if DB != nil {
-		DB.Close(context.Background())
+func CloseDB(conn *pgx.Conn) {
+	if conn != nil {
+		conn.Close(context.Background())
 	}
 }

--- a/models/metrics.go
+++ b/models/metrics.go
@@ -1,0 +1,8 @@
+package models
+
+type Metrics struct {
+	ID    string   `json:"id"`
+	MType string   `json:"type"` // "gauge" or "counter"
+	Delta *int64   `json:"delta,omitempty"`
+	Value *float64 `json:"value,omitempty"`
+}

--- a/storage/mem_storage.go
+++ b/storage/mem_storage.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/hairutdin/metrics-service/models"
 	"os"
 	"sync"
 	"time"
@@ -27,6 +28,19 @@ func (s *MemStorage) UpdateGauge(name string, value float64) {
 	s.Lock()
 	defer s.Unlock()
 	s.Gauges[name] = value
+}
+
+func (ms *MemStorage) UpdateMetricsBatch(metrics []models.Metrics) error {
+	ms.Lock()
+	defer ms.Unlock()
+	for _, metric := range metrics {
+		if metric.MType == "gauge" {
+			ms.Gauges[metric.ID] = *metric.Value
+		} else if metric.MType == "counter" {
+			ms.Counters[metric.ID] += *metric.Delta
+		}
+	}
+	return nil
 }
 
 func (s *MemStorage) UpdateCounter(name string, value int64) {

--- a/storage/postgres_storage_test.go
+++ b/storage/postgres_storage_test.go
@@ -1,19 +1,31 @@
 package storage
 
 import (
+	"context"
 	"fmt"
-	"github.com/hairutdin/metrics-service/internal/db"
-	"github.com/stretchr/testify/assert"
 	"strconv"
 	"testing"
+
+	"github.com/hairutdin/metrics-service/internal/db"
+	"github.com/hairutdin/metrics-service/models"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/assert"
 )
 
-func TestPostgresStorage(t *testing.T) {
-	err := db.ConnectToDB("postgres://postgres:postgres@localhost:5432/metrics_service?sslmode=disable")
-	assert.NoError(t, err)
-	defer db.CloseDB()
+func clearTables(conn *pgx.Conn) {
+	_, _ = conn.Exec(context.Background(), "TRUNCATE gauge_metrics, counter_metrics")
+}
 
-	storage := NewPostgresStorage()
+func TestPostgresStorage(t *testing.T) {
+	conn, err := db.ConnectToDB("postgres://postgres:postgres@localhost:5432/metrics_service_test?sslmode=disable")
+	assert.NoError(t, err)
+	defer db.CloseDB(conn)
+
+	err = db.InitializeTables(conn)
+	assert.NoError(t, err)
+
+	storage := NewPostgresStorage(conn)
 
 	storage.UpdateGauge("test_gauge", 42.0)
 	value, err := storage.GetMetric("gauge", "test_gauge")
@@ -28,4 +40,43 @@ func TestPostgresStorage(t *testing.T) {
 	value, err = storage.GetMetric("counter", "test_counter")
 	assert.NoError(t, err)
 	assert.Equal(t, "5", value)
+}
+
+func TestUpdateMetricsBatch(t *testing.T) {
+	conn, err := db.ConnectToDB("postgres://postgres:postgres@localhost:5432/metrics_service_test?sslmode=disable")
+	if err != nil {
+		t.Fatalf("Failed to connect to database: %v", err)
+	}
+	defer db.CloseDB(conn)
+
+	clearTables(conn)
+
+	storage := NewPostgresStorage(conn)
+
+	metrics := []models.Metrics{
+		{
+			ID:    "test_gauge",
+			MType: "gauge",
+			Value: func(f float64) *float64 { v := f; return &v }(42.5)},
+		{
+			ID:    "test_counter",
+			MType: "counter",
+			Delta: func(i int64) *int64 { d := i; return &d }(10)},
+	}
+
+	err = storage.UpdateMetricsBatch(metrics)
+	assert.NoError(t, err)
+
+	value, err := storage.GetMetric("gauge", "test_gauge")
+	assert.NoError(t, err)
+
+	floatValue, err := strconv.ParseFloat(value, 64)
+	assert.NoError(t, err)
+
+	formattedValue := fmt.Sprintf("%.6f", floatValue)
+	assert.Equal(t, "42.500000", formattedValue)
+
+	value, err = storage.GetMetric("counter", "test_counter")
+	assert.NoError(t, err)
+	assert.Equal(t, "10", value)
 }

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -1,8 +1,11 @@
 package storage
 
+import "github.com/hairutdin/metrics-service/models"
+
 type MetricsStorage interface {
 	UpdateGauge(name string, value float64)
 	UpdateCounter(name string, value int64)
+	UpdateMetricsBatch(metrics []models.Metrics) error
 	GetMetric(metricType string, name string) (string, error)
 	GetAllMetrics() map[string]string
 }


### PR DESCRIPTION
- Added a new POST /updates/ handler in the server to process multiple metrics in a single batch request. The handler supports receiving Gzip-compressed requests, storing metrics in a PostgreSQL database within a single transaction to avoid race conditions.
- Updated the agent to send batched metrics to the new endpoint, ensuring backward compatibility with the existing functionality.
- Optimized storage by skipping empty batches and enabled support for compressed payloads.